### PR TITLE
fix: update for new treesitter capture names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Updates to [tree-sitter capture names](https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1900679583)
+
 ### Improvements
 
 - Code styling and linting with stylua and selene.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-## Unreleased
+## Version `0.1.1` - 2024-03-24
 
 ### Fixes
 
 - Updates to [tree-sitter capture names](https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1900679583)
-
-### Improvements
-
-- Code styling and linting with stylua and selene.
 
 ### Changes
 
 - Docstrings that are actual strings (such as in Python) are now rendered like comments.
 - `TODO`/`NOTE`/`FIX`/`BUG`/... within comments are rendered according to warning levels.
 
-## Release 0.1.0 - 2024-03-20
+### Improvements
+
+- Code styling and linting with Stylua and Selene.
+
+## Version `0.1.0` - 2024-03-20
 
 Initial version from [WittyJudge](https://github.com/WIttyJudge).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Code styling and linting with stylua and selene.
 
+### Changes
+
+- Docstrings that are actual strings (such as in Python) are now rendered like comments.
+- `TODO`/`NOTE`/`FIX`/`BUG`/... within comments are rendered according to warning levels.
+
 ## Release 0.1.0 - 2024-03-20
 
 Initial version from [WittyJudge](https://github.com/WIttyJudge).

--- a/assets/sample.md
+++ b/assets/sample.md
@@ -6,11 +6,11 @@
 ###### H6
 
 > Quote with `inline code`, a [link](https://example.com), **bold text**, *italic text*,
-> ~~strikethrough~~, _underlined_, ***bold and italic***.
+> ~~strikethrough~~, ***bold and italic***.
 
 
 Some outside of quote with `inline code`, a [link](https://example.com), **bold text**, *italic
-text*, ~~strikethrough~~, _underlined_, ***bold and italic***.
+text*, ~~strikethrough~~, ***bold and italic***.
 
 ![some alt text](./some/path/to/image.png)
 
@@ -30,6 +30,7 @@ function Object:new(this, that)
   self._this.do(true)
   if this then
     -- comment
+    b = a + c
     print(type(string.gsub(that, "%b{} %d%s")) == nil and 1 or 1.12)
   end
 end
@@ -66,3 +67,4 @@ fn main() -> Result<()> {
 ```
 
 <!-- TODO: add more languages; leave comment to also support comments -->
+<!-- some link in the comments: https://github.com/nvim-treesitter -->

--- a/assets/sample.md
+++ b/assets/sample.md
@@ -48,7 +48,6 @@ function Object:new(this, that)
     b = a + c
     print(type(string.gsub(that, "%b{} \n%d%s")) == nil and 1 or 1.12)
     string.format("%s=%d", this, that)
-
   end
 end
 ```

--- a/assets/sample.md
+++ b/assets/sample.md
@@ -17,21 +17,38 @@ text*, ~~strikethrough~~, ***bold and italic***.
 > [!NOTE]
 > Sample GitHub style note
 
+- some
+- unnumbered
+- list
+- [ ] with checkbox
+- [x] that is checked
+
+1. Some numbered list
+2. Some numbered list
+
 ```
 Code without explicit language
 ```
 
+```diff
++["@string.escape"] = { link = "Yellow" },
+-["@string.escape"] = { link = "Green" },
+```
+
 ```lua
 local string = require("string")
+local CONSTANT = "test"
 ---docstring
 ---@param this string does stuff
 ---@return table
 function Object:new(this, that)
   self._this.do(true)
   if this then
-    -- comment
+    -- NOTE: comment
     b = a + c
-    print(type(string.gsub(that, "%b{} %d%s")) == nil and 1 or 1.12)
+    print(type(string.gsub(that, "%b{} \n%d%s")) == nil and 1 or 1.12)
+    string.format("%s=%d", this, that)
+
   end
 end
 ```
@@ -39,7 +56,7 @@ end
 ```python
 import module as m
 class Hello(abc.ABC):
-    # comment
+    # FIX: comment
     def test(self, other: str) -> int:
         """Docstring"""
         print(self.prop.method() == None and True or 1 || 1.23)
@@ -53,9 +70,9 @@ use clap:App;
 
 /// Some docstring
 fn main() -> Result<()> {
-    let yaml = load_yaml!("literal");
+    let yaml = load_yaml!("/path/to/some/file.png");
     let config = App:from_yaml(yaml).get_matches();
-    // some comment
+    // BUG: comment
     let val = match config.occurrences_of("this") {
         1 => Enum::Val1,
         _ => Enum::Val2,

--- a/assets/sample.md
+++ b/assets/sample.md
@@ -1,0 +1,68 @@
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+
+> Quote with `inline code`, a [link](https://example.com), **bold text**, *italic text*,
+> ~~strikethrough~~, _underlined_, ***bold and italic***.
+
+
+Some outside of quote with `inline code`, a [link](https://example.com), **bold text**, *italic
+text*, ~~strikethrough~~, _underlined_, ***bold and italic***.
+
+![some alt text](./some/path/to/image.png)
+
+> [!NOTE]
+> Sample GitHub style note
+
+```
+Code without explicit language
+```
+
+```lua
+local string = require("string")
+---docstring
+---@param this string does stuff
+---@return table
+function Object:new(this, that)
+  self._this.do(true)
+  if this then
+    -- comment
+    print(type(string.gsub(that, "%b{} %d%s")) == nil and 1 or 1.12)
+  end
+end
+```
+
+```python
+import module as m
+class Hello(abc.ABC):
+    # comment
+    def test(self, other: str) -> int:
+        """Docstring"""
+        print(self.prop.method() == None and True or 1 || 1.23)
+```
+
+```rust
+#[macro_use]
+extern crate log;
+mod other;
+use clap:App;
+
+/// Some docstring
+fn main() -> Result<()> {
+    let yaml = load_yaml!("literal");
+    let config = App:from_yaml(yaml).get_matches();
+    // some comment
+    let val = match config.occurrences_of("this") {
+        1 => Enum::Val1,
+        _ => Enum::Val2,
+    };
+    if let Some(val) = other {
+        return None == 1.23;
+    }
+}
+```
+
+<!-- TODO: add more languages; leave comment to also support comments -->

--- a/lua/gruvbox-material/highlights.lua
+++ b/lua/gruvbox-material/highlights.lua
@@ -444,12 +444,12 @@ function highlights.treesitter()
     ["@variable.parameter.builtin"] = { link = "@variable.builtin" },
     ["@variable.member"] = { link = "@variable" },
 
-    ["@constant"] = { link = "Green" },
+    ["@constant"] = { link = "Aqua" },
     ["@constant.builtin"] = { link = "Yellow" },
     ["@constant.macro"] = { link = "Blue" },
 
-    ["@module"] = { link = "Fg" },
-    ["@module.builtin"] = { link = "Blue" },
+    ["@module"] = { link = "Blue" },
+    ["@module.builtin"] = { link = "@module" },
 
     ["@label"] = { link = "Orange" },
 
@@ -457,7 +457,7 @@ function highlights.treesitter()
     ["@string"] = { link = "Aqua" },
     ["@string.documentation"] = { link = "Comment" },
     ["@string.regexp"] = { link = "Green" },
-    ["@string.escape"] = { link = "Green" },
+    ["@string.escape"] = { link = "Yellow" },
     ["@string.special"] = { link = "@string" },
     ["@string.special.symbol"] = { link = "@string" },
     ["@string.special.url"] = { link = "Yellow" },
@@ -465,6 +465,7 @@ function highlights.treesitter()
 
     ["@character"] = { link = "Aqua" },
     ["@character.special"] = { link = "Aqua" },
+    ["@character.printf"] = { link = "Green" },
 
     ["@boolean"] = { link = "Boolean" },
     ["@number"] = { link = "Purple" },
@@ -513,7 +514,7 @@ function highlights.treesitter()
     -- punctuation
     ["@punctuation.delimiter"] = { link = "Fg" },
     ["@punctuation.bracket"] = { link = "Fg" },
-    ["@punctuation.special"] = { link = "Blue" },
+    ["@punctuation.special"] = { link = "Fg" },
 
     -- comments
     ["@comment"] = { link = "Comment" },

--- a/lua/gruvbox-material/highlights.lua
+++ b/lua/gruvbox-material/highlights.lua
@@ -438,17 +438,17 @@ function highlights.treesitter()
     -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights)
 
     -- identifiers
-    ["@variable"] = { link = "Fg" },
-    ["@variable.builtin"] = { link = "Blue" },
+    ["@variable"] = { link = "Blue" },
+    ["@variable.builtin"] = { link = "@variable" },
     ["@variable.parameter"] = { link = "@variable" },
     ["@variable.parameter.builtin"] = { link = "@variable.builtin" },
     ["@variable.member"] = { link = "@variable" },
 
-    ["@constant"] = { link = "Fg" },
-    ["@constant.builtin"] = { link = "Blue" },
+    ["@constant"] = { link = "Green" },
+    ["@constant.builtin"] = { link = "Yellow" },
     ["@constant.macro"] = { link = "Blue" },
 
-    ["@module"] = { link = "Yellow" },
+    ["@module"] = { link = "Fg" },
     ["@module.builtin"] = { link = "Blue" },
 
     ["@label"] = { link = "Orange" },
@@ -481,9 +481,9 @@ function highlights.treesitter()
 
     -- functions
     ["@function"] = { link = "Green" },
-    ["@function.builtin"] = { link = "@function" },
+    ["@function.builtin"] = { link = "Yellow" },
     ["@function.call"] = { link = "@function" },
-    ["@function.macro"] = { link = "@function" },
+    ["@function.macro"] = { link = "Aqua" },
 
     ["@function.method"] = { link = "Green" },
     ["@function.method.call"] = { link = "@method" },
@@ -495,7 +495,7 @@ function highlights.treesitter()
     ["@keyword"] = { link = "Red" },
     ["@keyword.coroutine"] = { link = "@keyword" },
     ["@keyword.function"] = { link = "@keyword" },
-    ["@keyword.operator"] = { link = "Orange" },
+    ["@keyword.operator"] = { link = "@keyword" },
     ["@keyword.import"] = { link = "@keyword" },
     ["@keyword.type"] = { link = "@keyword" },
     ["@keyword.modifier"] = { link = "@keyword" },
@@ -511,7 +511,7 @@ function highlights.treesitter()
     ["@keyword.directive.define"] = { link = "@keyword.directive" },
 
     -- punctuation
-    ["@punctuation.delimiter"] = { link = "Grey" },
+    ["@punctuation.delimiter"] = { link = "Fg" },
     ["@punctuation.bracket"] = { link = "Fg" },
     ["@punctuation.special"] = { link = "Blue" },
 

--- a/lua/gruvbox-material/highlights.lua
+++ b/lua/gruvbox-material/highlights.lua
@@ -373,7 +373,6 @@ function highlights.filetype_specific()
   return syntax
 end
 
--- TODO: Add more description.
 -----------------------------------
 -- Tresitter specific highlights --
 -- :h nvim-treesitter-highlights --
@@ -434,6 +433,136 @@ function highlights.treesitter()
     TSUnderline = { style = "underline" },
     TSVariable = { link = "Fg" },
     TSVariableBuiltin = { link = "Blue" },
+
+    -- NOTE: changes due to new capture names (see:
+    -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights)
+
+    -- identifiers
+    ["@variable"] = { link = "Fg" },
+    ["@variable.builtin"] = { link = "Blue" },
+    ["@variable.parameter"] = { link = "@variable" },
+    ["@variable.parameter.builtin"] = { link = "@variable.builtin" },
+    ["@variable.member"] = { link = "@variable" },
+
+    ["@constant"] = { link = "Fg" },
+    ["@constant.builtin"] = { link = "Blue" },
+    ["@constant.macro"] = { link = "Blue" },
+
+    ["@module"] = { link = "Yellow" },
+    ["@module.builtin"] = { link = "Blue" },
+
+    ["@label"] = { link = "Orange" },
+
+    -- literals
+    ["@string"] = { link = "Aqua" },
+    ["@string.documentation"] = { link = "Comment" },
+    ["@string.regexp"] = { link = "Green" },
+    ["@string.escape"] = { link = "Green" },
+    ["@string.special"] = { link = "@string" },
+    ["@string.special.symbol"] = { link = "@string" },
+    ["@string.special.url"] = { link = "Yellow" },
+    ["@string.special.path"] = { link = "@string" },
+
+    ["@character"] = { link = "Aqua" },
+    ["@character.special"] = { link = "Aqua" },
+
+    ["@boolean"] = { link = "Boolean" },
+    ["@number"] = { link = "Purple" },
+    ["@number.float"] = { link = "@number" },
+
+    -- types
+    ["@type"] = { link = "Yellow" },
+    ["@type.builtin"] = { link = "@type" },
+    ["@type.definition"] = { link = "@type" },
+
+    ["@attribute"] = { link = "Purple" },
+    ["@attribute.builtin"] = { link = "@attribute" },
+    ["@property"] = { link = "Green" },
+
+    -- functions
+    ["@function"] = { link = "Green" },
+    ["@function.builtin"] = { link = "@function" },
+    ["@function.call"] = { link = "@function" },
+    ["@function.macro"] = { link = "@function" },
+
+    ["@function.method"] = { link = "Green" },
+    ["@function.method.call"] = { link = "@method" },
+
+    ["@constructor"] = { link = "Green" },
+    ["@operator"] = { link = "Orange" },
+
+    -- keywords
+    ["@keyword"] = { link = "Red" },
+    ["@keyword.coroutine"] = { link = "@keyword" },
+    ["@keyword.function"] = { link = "@keyword" },
+    ["@keyword.operator"] = { link = "Orange" },
+    ["@keyword.import"] = { link = "@keyword" },
+    ["@keyword.type"] = { link = "@keyword" },
+    ["@keyword.modifier"] = { link = "@keyword" },
+    ["@keyword.repeat"] = { link = "@keyword" },
+    ["@keyword.return"] = { link = "@keyword" },
+    ["@keyword.debug"] = { link = "@keyword" },
+    ["@keyword.exception"] = { link = "@keyword" },
+
+    ["@keyword.conditional"] = { link = "Red" },
+    ["@keyword.conditional.ternary"] = { link = "@keyword.conditional" },
+
+    ["@keyword.directive"] = { link = "Red" },
+    ["@keyword.directive.define"] = { link = "@keyword.directive" },
+
+    -- punctuation
+    ["@punctuation.delimiter"] = { link = "Grey" },
+    ["@punctuation.bracket"] = { link = "Fg" },
+    ["@punctuation.special"] = { link = "Blue" },
+
+    -- comments
+    ["@comment"] = { link = "Comment" },
+    ["@comment.documentation"] = { link = "Comment" },
+
+    ["@comment.error"] = { link = "Error" },
+    ["@comment.warning"] = { link = "Warning" },
+    ["@comment.todo"] = { link = "Todo" },
+    ["@comment.note"] = { link = "Info" },
+
+    -- markup
+    ["@markup.strong"] = { style = "bold" },
+    ["@markup.italic"] = { style = "italic" },
+    ["@markup.strikethrough"] = { link = "Grey" },
+    ["@markup.underline"] = { style = "underline" },
+
+    -- ["@markup.heading"] = {},
+    ["@markup.heading.1"] = { fg = colors.red, style = "bold" },
+    ["@markup.heading.2"] = { fg = colors.orange, style = "bold" },
+    ["@markup.heading.3"] = { fg = colors.yellow, style = "bold" },
+    ["@markup.heading.4"] = { fg = colors.green, style = "bold" },
+    ["@markup.heading.5"] = { fg = colors.blue, stlye = "bold" },
+    ["@markup.heading.6"] = { fg = colors.purple, style = "bold" },
+
+    ["@markup.quote"] = { link = "Grey" },
+    ["@markup.math"] = { link = "Blue" },
+
+    ["@markup.link"] = { fg = colors.blue },
+    ["@markup.link.label"] = { fg = colors.blue },
+    ["@markup.link.url"] = { fg = colors.blue, style = "italic" },
+
+    ["@markup.raw"] = { link = "Purple" },
+    ["@markup.raw.inline"] = { link = "Purple" },
+    ["@markup.raw.block"] = { link = "Purple" },
+
+    ["@markup.list"] = { link = "Orange" },
+    ["@markup.list.checked"] = { link = "Green" },
+    ["@markup.list.numbered"] = { link = "Aqua" },
+    ["@markup.list.unchecked"] = { link = "Red" },
+    ["@markup.list.unnumbered"] = { link = "Orange" },
+
+    ["@diff.plus"] = { link = "DiffAdd" },
+    ["@diff.minus"] = { link = "DiffDelete" },
+    ["@diff.delta"] = { link = "DiffChange" },
+
+    ["@tag"] = { link = "Orange" },
+    ["@tag.builtin"] = { link = "@tag" },
+    ["@tag.attribute"] = { link = "@tag" },
+    ["@tag.delimiter"] = { link = "Green" },
   }
 
   return syntax


### PR DESCRIPTION
This should fix any issues due to new capture names in `nvim-treesitter`. I updated the highlight links in a way that should not modify the highlighting. The only sections where I am a bit unsure is the markdown stuff. Considering it was broken and I don't have a color reference for stuff like quotes or code blocks from before it broke (have been using a slightly modified version of this for quite a time), I used what seemed reasonable.

I will test it against some code samples manually. Not sure how one could automate regression tests for colorschemes ...

Fixes #2 