### PR TITLE
Fixed variable text colors. Changed treesitter capture names links

### DIFF
--- a/lua/gruvbox-material/highlights.lua
+++ b/lua/gruvbox-material/highlights.lua
@@ -31,7 +31,7 @@ function highlights.custom()
     Success = { link = "Green" },
     Hint = { link = "Green" },
 
-    ErrorFloat = { fg = colors.red, bg = colors.bg3 },
+    ErrorFloat = { fg = colors.blue, bg = colors.bg3 },
     WarningFloat = { fg = colors.yellow, bg = colors.bg3 },
     InfoFloat = { fg = colors.blue, bg = colors.bg3 },
     HintFloat = { fg = colors.green, bg = colors.bg3 },
@@ -99,44 +99,44 @@ end
 -----------------------
 function highlights.syntax()
   local syntax = {
-    Type = { fg = colors.yellow }, -- int, long, char, etc.
-    Typedef = { fg = colors.red }, -- A typedef
-    StorageClass = { fg = colors.orange }, -- static, register, volatile, etc.
-    Structure = { fg = colors.orange }, -- struct, union, enum, etc.
-    Constant = { fg = colors.aqua }, -- any constant
-    Character = { fg = colors.green }, -- any character constant: 'c', '\n'
-    Number = { fg = colors.purple }, -- a number constant: 5
-    Boolean = { fg = colors.purple }, -- a boolean constant: TRUE, false
-    Float = { fg = colors.purple }, -- a floating point constant: 2.3e10
-    Statement = { fg = colors.red }, -- any statement
-    Label = { fg = colors.orange }, -- case, default, etc.
-    Operator = { fg = colors.orange }, -- sizeof", "+", "*", etc.
-    Exception = { fg = colors.red }, -- try, catch, throw
-    PreProc = { fg = colors.purple }, -- generic Preprocessor
-    Include = { fg = colors.purple }, -- preprocessor #include
-    Define = { fg = colors.purple }, -- preprocessor #define
+    Type = { fg = colors.yellow },                         -- int, long, char, etc.
+    Typedef = { fg = colors.red },                         -- A typedef
+    StorageClass = { fg = colors.orange },                 -- static, register, volatile, etc.
+    Structure = { fg = colors.orange },                    -- struct, union, enum, etc.
+    Constant = { fg = colors.aqua },                       -- any constant
+    Character = { fg = colors.green },                     -- any character constant: 'c', '\n'
+    Number = { fg = colors.purple },                       -- a number constant: 5
+    Boolean = { fg = colors.purple },                      -- a boolean constant: TRUE, false
+    Float = { fg = colors.purple },                        -- a floating point constant: 2.3e10
+    Statement = { fg = colors.red },                       -- any statement
+    Label = { fg = colors.orange },                        -- case, default, etc.
+    Operator = { fg = colors.orange },                     -- sizeof", "+", "*", etc.
+    Exception = { fg = colors.red },                       -- try, catch, throw
+    PreProc = { fg = colors.purple },                      -- generic Preprocessor
+    Include = { fg = colors.purple },                      -- preprocessor #include
+    Define = { fg = colors.purple },                       -- preprocessor #define
     Identifier = { fg = colors.blue },
-    Macro = { fg = colors.aqua }, -- same as Define
-    PreCondit = { fg = colors.purple }, -- preprocessor #if, #else, #endif, etc.
-    Special = { fg = colors.yellow }, -- any special symbol
-    SpecialChar = { fg = colors.yellow }, -- special character in a constant
-    Function = { fg = colors.green }, -- special character in a constant
-    Tag = { fg = colors.orange }, -- you can use CTRL-] on this
-    Delimiter = { fg = colors.fg0 }, -- character that needs attention like , or .
+    Macro = { fg = colors.aqua },                          -- same as Define
+    PreCondit = { fg = colors.purple },                    -- preprocessor #if, #else, #endif, etc.
+    Special = { fg = colors.yellow },                      -- any special symbol
+    SpecialChar = { fg = colors.yellow },                  -- special character in a constant
+    Function = { fg = colors.green },                      -- special character in a constant
+    Tag = { fg = colors.orange },                          -- you can use CTRL-] on this
+    Delimiter = { fg = colors.fg0 },                       -- character that needs attention like , or .
     QuickFixLine = { fg = colors.purple, style = "bold" }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
-    Debug = { fg = colors.orange }, -- debugging statements
-    debucPC = { fg = colors.bg0, bg = colors.green }, -- the current position
-    debugBreakpoint = { fg = colors.bg0 }, -- a breakpoint
+    Debug = { fg = colors.orange },                        -- debugging statements
+    debucPC = { fg = colors.bg0, bg = colors.green },      -- the current position
+    debugBreakpoint = { fg = colors.bg0 },                 -- a breakpoint
     ToolbarLine = { fg = colors.fg1, bg = colors.bg3 },
     ToolbarButton = { fg = colors.fg0, bg = colors.grey2 },
     Underlined = { fg = colors.blue, style = "underline" }, -- text that stands out, HTML links
-    Ignore = { fg = colors.grey1 }, -- left blank, hidden
+    Ignore = { fg = colors.grey1 },                         -- left blank, hidden
   }
 
   if g.gruvbox_material_enable_italic_comment == 1 then
-    syntax.Comment = { fg = colors.grey1, style = "italic" } -- any comments
+    syntax.Comment = { fg = colors.grey1, style = "italic" }        -- any comments
     syntax.SpecialComment = { fg = colors.grey1, style = "italic" } -- special things inside a comment
-    syntax.Todo = { fg = colors.purple, style = "italic" } -- anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+    syntax.Todo = { fg = colors.purple, style = "italic" }          -- anything that needs extra attention; mostly the keywords TODO FIXME and XXX
   else
     syntax.Comment = { fg = colors.grey1 }
     syntax.SpecialComment = { fg = colors.grey1 }
@@ -152,10 +152,10 @@ end
 function highlights.highlight_groups()
   local syntax = {
     ColorColumn = { bg = colors.bg2 }, --  used for the columns set with 'colorcolumn'
-    Conceal = { bg = colors.bg5 }, -- placeholder characters substituted for concealed text (see 'conceallevel')
+    Conceal = { bg = colors.bg5 },     -- placeholder characters substituted for concealed text (see 'conceallevel')
 
-    Cursor = { style = "reverse" }, -- the character under the cursor
-    lCursor = { link = "Cursor" }, -- the character under the cursor
+    Cursor = { style = "reverse" },    -- the character under the cursor
+    lCursor = { link = "Cursor" },     -- the character under the cursor
     CursorIM = { link = "Cursor" },
 
     CursorLine = { bg = colors.bg1 },
@@ -163,60 +163,60 @@ function highlights.highlight_groups()
     CursorLineNr = { fg = colors.grey1 },
 
     -- Diff mode
-    DiffAdd = { bg = colors.bg_diff_green }, -- Added line
-    DiffChange = { bg = colors.bg_diff_blue }, --  Changed line
-    DiffDelete = { bg = colors.bg_diff_red }, -- Deleted line
-    DiffText = { fg = colors.bg0, bg = colors.blue }, -- Changed text within a changed line
+    DiffAdd = { bg = colors.bg_diff_green },                                -- Added line
+    DiffChange = { bg = colors.bg_diff_blue },                              --  Changed line
+    DiffDelete = { bg = colors.bg_diff_red },                               -- Deleted line
+    DiffText = { fg = colors.bg0, bg = colors.blue },                       -- Changed text within a changed line
 
     EndOfBuffer = { fg = colors.bg5, bg = colors.bg0, transparent = true }, -- filler lines (~) after the last line in the buffer
 
-    VertSplit = { fg = colors.bg5 }, -- the column separating verti-- cally split windows
+    VertSplit = { fg = colors.bg5 },                                        -- the column separating verti-- cally split windows
 
-    Directory = { fg = colors.green }, -- directory names (and other special names in listings)
-    Folded = { fg = colors.grey1, bg = colors.bg2 }, -- line used for closed folds
+    Directory = { fg = colors.green },                                      -- directory names (and other special names in listings)
+    Folded = { fg = colors.grey1, bg = colors.bg2 },                        -- line used for closed folds
     FoldColumn = { fg = colors.grey1 },
-    SignColumn = { fg = colors.fg0 }, -- column where signs are displayed
+    SignColumn = { fg = colors.fg0 },                                       -- column where signs are displayed
 
-    IncSearch = { fg = colors.bg0, bg = colors.bg_red }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
-    Search = { fg = colors.bg0, bg = colors.bg_green }, -- Last search pattern highlighting (see 'hlsearch'). Also used for similar items that need to stand out.
-    LineNr = { fg = colors.bg5 }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
+    IncSearch = { fg = colors.bg0, bg = colors.bg_red },                    -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
+    Search = { fg = colors.bg0, bg = colors.bg_green },                     -- Last search pattern highlighting (see 'hlsearch'). Also used for similar items that need to stand out.
+    LineNr = { fg = colors.bg5 },                                           -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
 
-    ErrorMsg = { link = "Error" }, -- error messages on the command line
-    WarningMsg = { fg = colors.yellow, style = "bold" }, --  warning messages
-    ModeMsg = { fg = colors.fg0, style = "bold" }, -- 'showmode' message (e.g., "-- INSERT --")
-    MoreMsg = { fg = colors.yellow, style = "bold" }, -- more-prompt
-    MatchParen = { bg = colors.bg4 }, -- The character under the cursor or just before it, if it is a paired bracket, and its match.
-    NonText = { fg = colors.bg5 }, -- '~' and '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line).
-    Whitespace = { fg = colors.bg5 }, -- '~' and '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line).
-    SpecialKey = { fg = colors.bg5 }, -- Meta and special keys listed with ":map", also for text used to show unprintable characters in the text, 'listchars'. Generally: text that is displayed differently from what it really is.
-    Title = { fg = colors.orange, style = "bold" }, -- titles for output from ":set all", ":autocmd" etc.
+    ErrorMsg = { link = "Error" },                                          -- error messages on the command line
+    WarningMsg = { fg = colors.yellow, style = "bold" },                    --  warning messages
+    ModeMsg = { fg = colors.fg0, style = "bold" },                          -- 'showmode' message (e.g., "-- INSERT --")
+    MoreMsg = { fg = colors.yellow, style = "bold" },                       -- more-prompt
+    MatchParen = { bg = colors.bg4 },                                       -- The character under the cursor or just before it, if it is a paired bracket, and its match.
+    NonText = { fg = colors.bg5 },                                          -- '~' and '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line).
+    Whitespace = { fg = colors.bg5 },                                       -- '~' and '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line).
+    SpecialKey = { fg = colors.bg5 },                                       -- Meta and special keys listed with ":map", also for text used to show unprintable characters in the text, 'listchars'. Generally: text that is displayed differently from what it really is.
+    Title = { fg = colors.orange, style = "bold" },                         -- titles for output from ":set all", ":autocmd" etc.
 
     -- Popup menu
-    Pmenu = { fg = colors.fg1, bg = colors.bg3 }, -- normal item
-    PmenuSel = { fg = colors.bg3, bg = colors.grey2 }, -- selected item
-    PmenuSbar = { bg = colors.bg3 }, -- scrollbar
-    PmenuThumb = { bg = colors.grey0 }, -- Thumb of the scrollbar
+    Pmenu = { fg = colors.fg1, bg = colors.bg3 },                      -- normal item
+    PmenuSel = { fg = colors.bg3, bg = colors.grey2 },                 -- selected item
+    PmenuSbar = { bg = colors.bg3 },                                   -- scrollbar
+    PmenuThumb = { bg = colors.grey0 },                                -- Thumb of the scrollbar
 
     Normal = { fg = colors.fg0, bg = colors.bg0, transparent = true }, -- normal text
     NormalFloat = { fg = colors.fg1, bg = colors.bg3, transparent = true },
 
-    Question = { fg = colors.yellow }, -- hit-enter prompt and yes/no questions
+    Question = { fg = colors.yellow },                              -- hit-enter prompt and yes/no questions
 
-    SpellBad = { style = "undercurl" }, -- Word that is not recognized by the spellchecker. This will be combined with the highlighting used otherwise.
-    SpellCap = { style = "undercurl" }, -- Word that should start with a capital. This will be combined with the highlighting used otherwise.
-    SpellLocal = { style = "undercurl" }, -- Word that is recognized by the spellchecker as one that is used in another region. This will be combined with the highlighting used otherwise.
-    SpellRare = { style = "undercurl" }, -- Word that is recognized by the spellchecker as one that is hardly ever used. spell This will be combined with the highlighting used otherwise.
+    SpellBad = { style = "undercurl" },                             -- Word that is not recognized by the spellchecker. This will be combined with the highlighting used otherwise.
+    SpellCap = { style = "undercurl" },                             -- Word that should start with a capital. This will be combined with the highlighting used otherwise.
+    SpellLocal = { style = "undercurl" },                           -- Word that is recognized by the spellchecker as one that is used in another region. This will be combined with the highlighting used otherwise.
+    SpellRare = { style = "undercurl" },                            -- Word that is recognized by the spellchecker as one that is hardly ever used. spell This will be combined with the highlighting used otherwise.
 
-    StatusLine = { fg = colors.fg1, bg = colors.bg_statusline1 }, -- status line of current window
-    StatusLineTerm = { link = "StatusLine" }, -- status line of current :terminal window
+    StatusLine = { fg = colors.fg1, bg = colors.bg_statusline1 },   -- status line of current window
+    StatusLineTerm = { link = "StatusLine" },                       -- status line of current :terminal window
     StatusLineNC = { fg = colors.fg1, bg = colors.bg_statusline1 }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
-    StatusLineTermNC = { link = "StatusLineNC" }, -- status line of non-current :terminal window
+    StatusLineTermNC = { link = "StatusLineNC" },                   -- status line of non-current :terminal window
     TabLine = { fg = colors.fg1, bg = colors.bg_statusline3 },
     TabLineFill = { fg = colors.fg1, bg = colors.bg_statusline1 },
     TabLineSel = { fg = colors.bg0, bg = colors.grey2 },
 
-    Visual = { bg = colors.bg3 }, -- Visual mode selection
-    VisualNOS = { link = "Visual" }, -- Visual mode selection when vim is "Not Owning the Selection". Only X11 Gui's gui-x11 and xterm-clipboard supports this.
+    Visual = { bg = colors.bg3 },     -- Visual mode selection
+    VisualNOS = { link = "Visual" },  -- Visual mode selection when vim is "Not Owning the Selection". Only X11 Gui's gui-x11 and xterm-clipboard supports this.
     WildMenu = { link = "PmenuSel" }, --  current match in 'wildmenu' completion
 
     -- ----------------------
@@ -224,34 +224,34 @@ function highlights.highlight_groups()
     -- ----------------------
 
     -- LSP Groups (descriptions and ordering from `:h lsp-highlight`)
-    LspDiagnosticsDefaultError = { link = "ErrorText" }, -- used for "Error" diagnostic virtual text
-    LspDiagnosticsDefaultHint = { link = "HintText" }, -- used for "Hint" diagnostic virtual text
-    LspDiagnosticsDefaultInformation = { link = "InfoText" }, -- used for "Information" diagnostic virtual text
-    LspDiagnosticsDefaultWarning = { link = "WarningText" }, -- used for "Warning" diagnostic signs in sign column
+    LspDiagnosticsDefaultError = { link = "ErrorText" },                 -- used for "Error" diagnostic virtual text
+    LspDiagnosticsDefaultHint = { link = "HintText" },                   -- used for "Hint" diagnostic virtual text
+    LspDiagnosticsDefaultInformation = { link = "InfoText" },            -- used for "Information" diagnostic virtual text
+    LspDiagnosticsDefaultWarning = { link = "WarningText" },             -- used for "Warning" diagnostic signs in sign column
 
-    LspDiagnosticsSignError = { link = "RedSign" }, -- used for "Error" diagnostic signs in sign column
-    LspDiagnosticsSignHint = { link = "AquaSign" }, -- used for "Hint" diagnostic signs in sign column
-    LspDiagnosticsSignInformation = { link = "BlueSign" }, -- used for "Information" diagnostic signs in sign column
-    LspDiagnosticsSignWarning = { link = "YellowSign" }, -- used for "Warning" diagnostic signs in sign column
+    LspDiagnosticsSignError = { link = "RedSign" },                      -- used for "Error" diagnostic signs in sign column
+    LspDiagnosticsSignHint = { link = "AquaSign" },                      -- used for "Hint" diagnostic signs in sign column
+    LspDiagnosticsSignInformation = { link = "BlueSign" },               -- used for "Information" diagnostic signs in sign column
+    LspDiagnosticsSignWarning = { link = "YellowSign" },                 -- used for "Warning" diagnostic signs in sign column
 
-    LspDiagnosticsFloatingError = { link = "ErrorFloat" }, -- used for "Error" diagnostic messages in the diagnostics float
-    LspDiagnosticsFloatingHint = { link = "HintFloat" }, -- used for "Hint" diagnostic messages in the diagnostics float
-    LspDiagnosticsFloatingInformation = { link = "InfoFloat" }, -- used for "Information" diagnostic messages in the diagnostics float
-    LspDiagnosticsFloatingWarning = { link = "WarningFloat" }, -- used for "Warning" diagnostic messages in the diagnostics float
+    LspDiagnosticsFloatingError = { link = "ErrorFloat" },               -- used for "Error" diagnostic messages in the diagnostics float
+    LspDiagnosticsFloatingHint = { link = "HintFloat" },                 -- used for "Hint" diagnostic messages in the diagnostics float
+    LspDiagnosticsFloatingInformation = { link = "InfoFloat" },          -- used for "Information" diagnostic messages in the diagnostics float
+    LspDiagnosticsFloatingWarning = { link = "WarningFloat" },           -- used for "Warning" diagnostic messages in the diagnostics float
 
-    LspDiagnosticsVirtualTextError = { link = "VirtualTextError" }, -- Virtual text "Error"
-    LspDiagnosticsVirtualTextHint = { link = "VirtualTextHint" }, -- Virtual text "Hint"
+    LspDiagnosticsVirtualTextError = { link = "VirtualTextError" },      -- Virtual text "Error"
+    LspDiagnosticsVirtualTextHint = { link = "VirtualTextHint" },        -- Virtual text "Hint"
     LspDiagnosticsVirtualTextInformation = { link = "VirtualTextInfo" }, -- Virtual text "Information"
-    LspDiagnosticsVirtualTextWarning = { link = "VirtualTextWarning" }, -- Virtual text "Warning"
+    LspDiagnosticsVirtualTextWarning = { link = "VirtualTextWarning" },  -- Virtual text "Warning"
 
-    LspDiagnosticsUnderlineError = { link = "ErrorText" }, -- used to underline "Error" diagnostics.
-    LspDiagnosticsUnderlineHint = { link = "HintText" }, -- used to underline "Hint" diagnostics.
-    LspDiagnosticsUnderlineInformation = { link = "InfoText" }, -- used to underline "Information" diagnostics.
-    LspDiagnosticsUnderlineWarning = { link = "WarningText" }, -- used to underline "Warning" diagnostics.
+    LspDiagnosticsUnderlineError = { link = "ErrorText" },               -- used to underline "Error" diagnostics.
+    LspDiagnosticsUnderlineHint = { link = "HintText" },                 -- used to underline "Hint" diagnostics.
+    LspDiagnosticsUnderlineInformation = { link = "InfoText" },          -- used to underline "Information" diagnostics.
+    LspDiagnosticsUnderlineWarning = { link = "WarningText" },           -- used to underline "Warning" diagnostics.
 
-    LspReferenceRead = { link = "CurrentWord" }, -- used for highlighting "read" references
-    LspReferenceText = { link = "CurrentWord" }, -- used for highlighting "text" references
-    LspReferenceWrite = { link = "CurrentWord" }, -- used for highlighting "write" references
+    LspReferenceRead = { link = "CurrentWord" },                         -- used for highlighting "read" references
+    LspReferenceText = { link = "CurrentWord" },                         -- used for highlighting "text" references
+    LspReferenceWrite = { link = "CurrentWord" },                        -- used for highlighting "write" references
 
     TermCursor = { link = "Cursor" },
     healthError = { link = "Error" },
@@ -272,7 +272,7 @@ function highlights.filetype_specific()
     markdownH2 = { fg = colors.orange, style = "bold" },
     markdownH3 = { fg = colors.yellow, style = "bold" },
     markdownH4 = { fg = colors.green, style = "bold" },
-    markdownH5 = { fg = colors.blue, stlye = "bold" },
+    markdownH5 = { fg = colors.blue, style = "bold" },
     markdownH6 = { fg = colors.purple, style = "bold" },
     markdownUrl = { fg = colors.blue, style = "italic" },
     markdownItalic = { style = "italic" },
@@ -382,143 +382,148 @@ function highlights.treesitter()
     TSAnnotation = { link = "Purple" }, -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
     TSAttribute = { link = "Purple" },
     TSBold = { style = "bold" },
-    TSBoolean = { link = "Purple" }, -- For booleans.
-    TSCharacter = { link = "Aqua" }, -- For characters.
+    TSBoolean = { link = "Purple" },               -- For booleans.
+    TSCharacter = { link = "Aqua" },               -- For characters.
+    TSCharacterSpecial = { link = "SpecialChar" }, -- For characters.
     TSComment = { link = "Comment" },
     TSConditional = { link = "Red" },
     TSConstBuiltin = { link = "Blue" }, -- For constant that are built in the language: `nil` in Lua.
-    TSConstMacro = { link = "Blue" }, -- For constants that are defined by macros: `NULL` in C.
-    TSConstant = { link = "Fg" }, -- For constants
+    TSConstMacro = { link = "Blue" },   -- For constants that are defined by macros: `NULL` in C.
+    TSConstant = { link = "Fg" },       -- For constants
     TSConstructor = { link = "Green" }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     TSDanger = { fg = colors.bg0, bg = colors.red, style = "bold" },
     TSEmphasis = { style = "bold" },
-    TSError = { link = "Error" }, -- For syntax/parser errors.
-    TSException = { link = "Red" }, -- For exception related keywords.
-    TSField = { link = "Green" }, -- For fields.
-    TSFloat = { link = "Purple" }, -- For floats.
+    TSError = { link = "Error" },     -- For syntax/parser errors.
+    TSException = { link = "Red" },   -- For exception related keywords.
+    TSField = { link = "Green" },     -- For fields.
+    TSFloat = { link = "Purple" },    -- For floats.
     TSFuncBuiltin = { link = "Green" },
-    TSFuncMacro = { link = "Green" }, -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
+    TSFuncMacro = { link = "Green" }, -- For macro defined functions (calls and definitions): each `macro_rules` in Rust.
     TSFunction = { link = "Green" },
-    TSInclude = { link = "Red" }, -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
+    TSInclude = { link = "Red" },     -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
     TSKeyword = { link = "Red" },
     TSKeywordFunction = { link = "Red" },
     TSKeywordOperator = { link = "Orange" },
+    TSKeywordReturn = { link = "Red" },
     TSLabel = { link = "Orange" }, -- For labels: `label:` in C and `:label:` in Lua.
     TSMath = { fg = "Blue" },
     TSMethod = { link = "Green" },
-    TSNamespace = { link = "Yellow" }, -- For identifiers referring to modules and namespaces.
+    TSNamespace = { link = "Yellow" },          -- For identifiers referring to modules and namespaces.
     TSNone = { link = "Fg" },
-    TSNumber = { link = "Purple" }, -- For all numbers
-    TSOperator = { link = "Orange" }, -- For any operator: `+`, but also `->` and `*` in C.
-    TSParameter = { link = "Fg" }, -- For parameters of a function.
-    TSParameterReference = { link = "Fg" }, -- For references to parameters of a function.
-    TSProperty = { link = "Green" }, -- Same as `TSField`,accesing for struct members in C.
-    TSPunctBracket = { link = "Fg" }, -- For brackets and parens.
-    TSPunctDelimiter = { link = "Grey" }, -- For delimiters ie: `.`
-    TSPunctSpecial = { link = "Blue" }, -- For special punctutation that does not fall in the catagories before.
+    TSNumber = { link = "Purple" },             -- For all numbers
+    TSOperator = { link = "Orange" },           -- For any operator: `+`, but also `->` and `*` in C.
+    TSParameter = { link = "Fg" },              -- For parameters of a function.
+    TSParameterReference = { link = "Fg" },     -- For references to parameters of a function.
+    TSProperty = { link = "Green" },            -- Same as `TSField`,accessing for struct members in C.
+    TSPunctBracket = { link = "Fg" },           -- For brackets and parens.
+    TSPunctDelimiter = { link = "Grey" },       -- For delimiters ie: `.`
+    TSPunctSpecial = { link = "Blue" },         -- For special punctutation that does not fall in the categories before.
     TSRepeat = { link = "Red" },
-    TSStrike = { link = "Grey" }, -- For strikethrough text.
+    TSStrike = { link = "Grey" },               -- For strikethrough text.
     TSString = { link = "Aqua" },
-    TSStringEscape = { link = "Green" }, -- For escape characters within a string.
-    TSStringRegex = { link = "Green" }, -- For regexes.
-    TSStroung = { style = "bold" },
+    TSStringEscape = { link = "Green" },        -- For escape characters within a string.
+    TSStringRegex = { link = "Green" },         -- For regexes.
+    TSStringSpecial = { link = "SpecialChar" }, -- For regexes.
+    TSStrong = { style = "bold" },
     TSStructure = { link = "Blue" },
-    TSSymbol = { link = "Fg" }, -- For identifiers referring to symbols or atoms.
-    TSTag = { link = "Orange" }, -- Tags like html tag names.
-    TSTagDelimiter = { link = "Green" }, -- Tag delimiter like `<` `>` `/`
-    TSText = { link = "Green" }, -- For strings considered text in a markup language.
-    TSType = { link = "Yellow" }, -- For types.
-    TSTypeBuiltin = { link = "Yellow" }, -- For builtin types.
-    TSURI = { link = "markdownUrl" }, -- Any URI like a link or email.
+    TSSymbol = { link = "Fg" },             -- For identifiers referring to symbols or atoms.
+    TSTag = { link = "Orange" },            -- Tags like html tag names.
+    TSTagDelimiter = { link = "Green" },    -- Tag delimiter like `<` `>` `/`
+    TSText = { link = "Green" },            -- For strings considered text in a markup language.
+    TSType = { link = "Yellow" },           -- For types.
+    TSTypeBuiltin = { link = "Yellow" },    -- For builtin types.
+    TSTypeDefinition = { link = "Yellow" }, -- For builtin types.
+    TSURI = { link = "markdownUrl" },       -- Any URI like a link or email.
     TSUnderline = { style = "underline" },
     TSVariable = { link = "Fg" },
     TSVariableBuiltin = { link = "Blue" },
+    TSDefine = { link = "Define" },
 
     -- NOTE: changes due to new capture names (see:
     -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights)
 
     -- identifiers
-    ["@variable"] = { link = "Blue" },
-    ["@variable.builtin"] = { link = "@variable" },
-    ["@variable.parameter"] = { link = "@variable" },
-    ["@variable.parameter.builtin"] = { link = "@variable.builtin" },
-    ["@variable.member"] = { link = "@variable" },
+    ["@variable"] = { link = "TSVariable" },
+    ["@variable.builtin"] = { link = "TSVariableBuiltin" },
+    ["@variable.parameter"] = { link = "TSParameter" },
+    ["@variable.parameter.builtin"] = { link = "TSParameter" },
+    ["@variable.member"] = { link = "TSField" },
 
-    ["@constant"] = { link = "Aqua" },
-    ["@constant.builtin"] = { link = "Yellow" },
-    ["@constant.macro"] = { link = "Blue" },
+    ["@constant"] = { link = "TSConstant" },
+    ["@constant.builtin"] = { link = "TSConstBuiltin" },
+    ["@constant.macro"] = { link = "TSConstMacro" },
 
-    ["@module"] = { link = "Blue" },
+    ["@module"] = { link = "TSNamespace" },
     ["@module.builtin"] = { link = "@module" },
 
-    ["@label"] = { link = "Orange" },
+    ["@label"] = { link = "TSLabel" },
 
     -- literals
-    ["@string"] = { link = "Aqua" },
+    ["@string"] = { link = "TSString" },
     ["@string.documentation"] = { link = "Comment" },
-    ["@string.regexp"] = { link = "Green" },
-    ["@string.escape"] = { link = "Yellow" },
-    ["@string.special"] = { link = "@string" },
-    ["@string.special.symbol"] = { link = "@string" },
-    ["@string.special.url"] = { link = "Yellow" },
+    ["@string.regexp"] = { link = "TSStringRegex" },
+    ["@string.escape"] = { link = "TSStringEscape" },
+    ["@string.special"] = { link = "TSStringSpecial" },
+    ["@string.special.symbol"] = { link = "TSSymbol" },
+    ["@string.special.url"] = { link = "TSURI" },
     ["@string.special.path"] = { link = "@string" },
 
-    ["@character"] = { link = "Aqua" },
-    ["@character.special"] = { link = "Aqua" },
+    ["@character"] = { link = "TSCharacter" },
+    ["@character.special"] = { link = "TSCharacterSpecial" },
     ["@character.printf"] = { link = "Green" },
 
-    ["@boolean"] = { link = "Boolean" },
-    ["@number"] = { link = "Purple" },
-    ["@number.float"] = { link = "@number" },
+    ["@boolean"] = { link = "TSBoolean" },
+    ["@number"] = { link = "TSNumber" },
+    ["@number.float"] = { link = "TSFloat" },
 
     -- types
-    ["@type"] = { link = "Yellow" },
-    ["@type.builtin"] = { link = "@type" },
-    ["@type.definition"] = { link = "@type" },
+    ["@type"] = { link = "TSType" },
+    ["@type.builtin"] = { link = "TSTypeBuiltin" },
+    ["@type.definition"] = { link = "TSTypeDefinition" },
 
-    ["@attribute"] = { link = "Purple" },
+    ["@attribute"] = { link = "TSAttribute" },
     ["@attribute.builtin"] = { link = "@attribute" },
-    ["@property"] = { link = "Green" },
+    ["@property"] = { link = "TSProperty" },
 
     -- functions
-    ["@function"] = { link = "Green" },
-    ["@function.builtin"] = { link = "Yellow" },
-    ["@function.call"] = { link = "@function" },
-    ["@function.macro"] = { link = "Aqua" },
+    ["@function"] = { link = "TSFunction" },
+    ["@function.builtin"] = { link = "TSFuncBuiltin" },
+    ["@function.call"] = { link = "TSFunction" },
+    ["@function.macro"] = { link = "TSFunction" },
 
-    ["@function.method"] = { link = "Green" },
-    ["@function.method.call"] = { link = "@method" },
+    ["@function.method"] = { link = "TSMethod" },
+    ["@function.method.call"] = { link = "TSMethod" },
 
-    ["@constructor"] = { link = "Green" },
-    ["@operator"] = { link = "Orange" },
+    ["@constructor"] = { link = "TSConstructor" },
+    ["@operator"] = { link = "TSOperator" },
 
     -- keywords
-    ["@keyword"] = { link = "Red" },
+    ["@keyword"] = { link = "TSKeyword" },
     ["@keyword.coroutine"] = { link = "@keyword" },
-    ["@keyword.function"] = { link = "@keyword" },
-    ["@keyword.operator"] = { link = "@keyword" },
-    ["@keyword.import"] = { link = "@keyword" },
+    ["@keyword.function"] = { link = "TSKeywordFunction" },
+    ["@keyword.operator"] = { link = "TSKeywordOperator" },
+    ["@keyword.import"] = { link = "TSInclude" },
     ["@keyword.type"] = { link = "@keyword" },
     ["@keyword.modifier"] = { link = "@keyword" },
-    ["@keyword.repeat"] = { link = "@keyword" },
-    ["@keyword.return"] = { link = "@keyword" },
+    ["@keyword.repeat"] = { link = "TSRepeat" },
+    ["@keyword.return"] = { link = "TSKeywordReturn" },
     ["@keyword.debug"] = { link = "@keyword" },
-    ["@keyword.exception"] = { link = "@keyword" },
+    ["@keyword.exception"] = { link = "TSException" },
 
-    ["@keyword.conditional"] = { link = "Red" },
+    ["@keyword.conditional"] = { link = "TSConditional" },
     ["@keyword.conditional.ternary"] = { link = "@keyword.conditional" },
 
-    ["@keyword.directive"] = { link = "Red" },
+    ["@keyword.directive"] = { link = "TSDefine" },
     ["@keyword.directive.define"] = { link = "@keyword.directive" },
 
     -- punctuation
-    ["@punctuation.delimiter"] = { link = "Fg" },
-    ["@punctuation.bracket"] = { link = "Fg" },
-    ["@punctuation.special"] = { link = "Fg" },
+    ["@punctuation.delimiter"] = { link = "TSPunctDelimiter" },
+    ["@punctuation.bracket"] = { link = "TSPunctBracket" },
+    ["@punctuation.special"] = { link = "TSPunctSpecial" },
 
     -- comments
-    ["@comment"] = { link = "Comment" },
-    ["@comment.documentation"] = { link = "Comment" },
+    ["@comment"] = { link = "TSComment" },
+    ["@comment.documentation"] = { link = "TSComment" },
 
     ["@comment.error"] = { link = "Error" },
     ["@comment.warning"] = { link = "Warning" },
@@ -528,7 +533,7 @@ function highlights.treesitter()
     -- markup
     ["@markup.strong"] = { style = "bold" },
     ["@markup.italic"] = { style = "italic" },
-    ["@markup.strikethrough"] = { link = "Grey" },
+    ["@markup.strikethrough"] = { link = "TSStrike" },
     ["@markup.underline"] = { style = "underline" },
 
     -- ["@markup.heading"] = {},
@@ -536,7 +541,7 @@ function highlights.treesitter()
     ["@markup.heading.2"] = { fg = colors.orange, style = "bold" },
     ["@markup.heading.3"] = { fg = colors.yellow, style = "bold" },
     ["@markup.heading.4"] = { fg = colors.green, style = "bold" },
-    ["@markup.heading.5"] = { fg = colors.blue, stlye = "bold" },
+    ["@markup.heading.5"] = { fg = colors.blue, style = "bold" },
     ["@markup.heading.6"] = { fg = colors.purple, style = "bold" },
 
     ["@markup.quote"] = { link = "Grey" },

--- a/lua/gruvbox-material/highlights.lua
+++ b/lua/gruvbox-material/highlights.lua
@@ -31,7 +31,7 @@ function highlights.custom()
     Success = { link = "Green" },
     Hint = { link = "Green" },
 
-    ErrorFloat = { fg = colors.blue, bg = colors.bg3 },
+    ErrorFloat = { fg = colors.red, bg = colors.bg3 },
     WarningFloat = { fg = colors.yellow, bg = colors.bg3 },
     InfoFloat = { fg = colors.blue, bg = colors.bg3 },
     HintFloat = { fg = colors.green, bg = colors.bg3 },


### PR DESCRIPTION
This PR fixes the variable text color, which was previously blue. This was not consistent with [gruvbox-material](https://github.com/sainnhe/gruvbox-material/blob/80331fbbec9ba18590a17bc6b7d277d96c05c2b6/colors/gruvbox-material.vim#L758C15-L758C39). I also made the treesitter capture names more consistent, in light of how gruvbox-material does it.
By default, neovim adjusted the spacing on the comments. If this is not wanted, I can create another PR that does not contain those changes.


_Note: I'm sorry for the mess that happened while creating the PR, I pressed enter when typing the PR tittle and it automatically submitted it without me providing additional information_