### PR TITLE
fix: change fg color for non-current statusline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Support for [nvim-notify](https://github.com/rcarriga/nvim-notify)
 - Support for Neovim's Diagnostic highlights.
 
+### Fixed
+
+- Change foreground color for non-current statusline highlight group.
+
 ## [1.0.0] - 2024-05-05
 
 ### Added

--- a/lua/gruvbox-material/groups.lua
+++ b/lua/gruvbox-material/groups.lua
@@ -158,7 +158,7 @@ return {
 
   StatusLine = { fg = colors.fg1, bg = colors.bg_statusline1 }, -- status line of current window
   StatusLineTerm = { link = "StatusLine" }, -- status line of current :terminal window
-  StatusLineNC = { fg = colors.fg1, bg = colors.bg_statusline1 }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+  StatusLineNC = { fg = colors.grey1, bg = colors.bg_statusline1 }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
   StatusLineTermNC = { link = "StatusLineNC" }, -- status line of non-current :terminal window
   TabLine = { fg = colors.fg1, bg = colors.bg_statusline3 },
   TabLineFill = { fg = colors.fg1, bg = colors.bg_statusline1 },


### PR DESCRIPTION
If current and non-current statusline highlight groups are the same, neovim will use "^^^" in the status line of the current window. Changing the foreground to a muted grey will prevent this from happening.

Closes #22