### PR TITLE
Change DiagnosticUnnecessary color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- ## [unreleased] -->
+## [unreleased]
+
+### Changed
+
+- Change `DiagnosticUnnecessary` color from yellow to gray.
 
 ## [1.2.0] - 2024-05-11
 

--- a/lua/gruvbox-material/groups.lua
+++ b/lua/gruvbox-material/groups.lua
@@ -236,7 +236,7 @@ function groups.get(contrast)
     DiagnosticSignHint = { link = "GreenSign" },
     DiagnosticSignOk = { link = "GreenSign" },
     DiagnosticDeprecated = { link = "Grey" },
-    DiagnosticUnnecessary = { link = "Yellow" },
+    DiagnosticUnnecessary = { link = "Grey" },
 
     -----------------------
     -- Filetype specific --


### PR DESCRIPTION
This PR changes the color of the DiagnosticUnnecessary highlight color to one less flashy.
I.M.O yellow is too strong for a warning such as this. In Go, this variable needs to be removed, but in other languages (e.g: python), having an unused variable is fine and does not warrant this much flashiness.

Left: Before | Right: After
<img width="1708" alt="Screenshot 2024-05-17 at 13 57 43" src="https://github.com/f4z3r/gruvbox-material.nvim/assets/30477293/e4fc29ec-6687-45da-b8d4-9e5c58e82cee">

What do you think @f4z3r?