### PR TITLE
Add highlight group WinSeparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add support for
   [`visual-whitespace.nvim`](https://github.com/mcauley-penney/visual-whitespace.nvim).
+- Add highlight group [`WinSeparator`](https://neovim.io/doc/user/syntax.html#hl-WinSeparator) which replaces `VertSplit` in newer versions of Neovim.
+- Add highlight group [`FloatBorder`](https://neovim.io/doc/user/syntax.html#hl-FloatBorder) (linked to [`WinSeparator`](https://neovim.io/doc/user/syntax.html#hl-WinSeparator)).
 
 ## [1.7.0] - 2025-07-06
 

--- a/lua/gruvbox-material/groups.lua
+++ b/lua/gruvbox-material/groups.lua
@@ -124,7 +124,8 @@ function groups.get(contrast)
 
     EndOfBuffer = { fg = colors.bg5, bg = colors.bg0 }, -- filler lines (~) after the last line in the buffer
 
-    VertSplit = { fg = colors.bg5 }, -- the column separating verti-- cally split windows
+    VertSplit = { fg = colors.bg5 }, -- the column separating vertically split windows
+    WinSeparator = { link = "VertSplit" }, -- replaces VertSplit in newer versions of Neovim
 
     Directory = { fg = colors.green }, -- directory names (and other special names in listings)
     Folded = { fg = colors.grey1, bg = colors.bg2 }, -- line used for closed folds
@@ -157,6 +158,7 @@ function groups.get(contrast)
     Normal = { fg = colors.fg0, bg = colors.bg0 }, -- normal text
     NormalNC = { link = "Normal" },
     NormalFloat = { fg = colors.fg1, bg = colors.bg3 },
+    FloatBorder = { link = "NormalFloat", fg = colors.bg5 },
 
     Question = { fg = colors.yellow }, -- hit-enter prompt and yes/no questions
 


### PR DESCRIPTION
## Description of changes

- Add the highlight group `WinSeparator` which replaces `VertSplit` in newer versions of Neovim.
(See [`hl-WinSepatator`](https://neovim.io/doc/user/syntax.html#hl-WinSeparator) and the [deprecation notice](https://neovim.io/doc/user/deprecated) -- search for `hl-VertSplit`.)
- Add the highlight group [`FloatBorder`](https://neovim.io/doc/user/syntax.html#hl-FloatBorder), linked to `WinSeparator`.


## Tests

- Tested with configurations:
  - [ ] transparent/non-transparent background
  - [ ] transparent/non-transparent floats

### Test Matrix

| Contrast |          Dark           |          Light          |
|   :-:    |           :-:           |           :-:           |
|   Soft   | <ul><li> [X] </li></ul> | <ul><li> [X] </li></ul> |
|  Medium  | <ul><li> [X] </li></ul> | <ul><li> [X] </li></ul> |
|   Hard   | <ul><li> [X] </li></ul> | <ul><li> [X] </li></ul> |
